### PR TITLE
Open up `isCsvTsvOrTextFile()` for public helper method

### DIFF
--- a/helpers/file.cfc
+++ b/helpers/file.cfc
@@ -95,11 +95,10 @@ component extends="base" accessors="true"{
 		return this;
 	}	
 
-	/* Private */
-
-	private boolean function isCsvTsvOrTextFile( required string path ){
+	public boolean function isCsvTsvOrTextFile( required string path ){
 		var contentType = getFileContentTypeFromPath( arguments.path );
 		return ListFindNoCase( "csv,tab-separated-values,plain", contentType );//Lucee=text/plain ACF=text/csv tsv=text/tab-separated-values
 	}
+	/* Private */
 
 }


### PR DESCRIPTION
I propose opening up the file helper's `isCsvTsvOrTextFile()` method.

Doing this, we could easily toggle between an XLS import and a CSV import via the following:

```
if ( spreadsheet.getFileHelper().isCsvTsvOrTextFile( arguments.filePath ) ){
    var sheet = spreadsheet.csvToQuery(
        src              = arguments.filePath,
        firstRowIsHeader = true
    );
} else {
    var sheet = spreadsheet.read(
        src       = arguments.filePath,
        format    = "query",
        headerRow = 1
    );
}
```

Thoughts?