### PR TITLE
add parallelization to queryToCSV

### DIFF
--- a/Spreadsheet.cfc
+++ b/Spreadsheet.cfc
@@ -1092,8 +1092,9 @@ component accessors="true"{
 		return new( sheetName=arguments.sheetName, xmlFormat=true );
 	}
 
-	public string function queryToCsv( required query query, boolean includeHeaderRow=false, string delimiter="," ){
-		var data = getCsvHelper().queryToArrayForCsv( arguments.query, arguments.includeHeaderRow );
+	/* row order is not guaranteed if using more than one thread */
+	public string function queryToCsv( required query query, boolean includeHeaderRow=false, string delimiter=",", numeric threads=1 ){
+		var data = getCsvHelper().queryToArrayForCsv( arguments.query, arguments.includeHeaderRow, arguments.threads );
 		var builder = getStringHelper().newJavaStringBuilder();
 		var csvFormat = getCsvHelper().delimiterIsTab( arguments.delimiter )?
 			createJavaObject( "org.apache.commons.csv.CSVFormat" )[ JavaCast( "string", "TDF" ) ]

--- a/helpers/csv.cfc
+++ b/helpers/csv.cfc
@@ -24,23 +24,24 @@ component extends="base"{
 		return result;
 	}
 
-	array function queryToArrayForCsv( required query query, required boolean includeHeaderRow ){
+	/* row order is not guaranteed if using more than one thread */
+	array function queryToArrayForCsv( required query query, required boolean includeHeaderRow, numeric threads=1){
 		var result = [];
 		var columns = getQueryHelper()._QueryColumnArray( arguments.query );
 		if( arguments.includeHeaderRow )
 			result.Append( columns );
-		for( var row IN arguments.query ){
+		queryEach(arguments.query, function(row){
 			var rowValues = [];
-			for( var column IN columns ){
+			arrayEach(columns, function(column){
 				var cellValue = row[ column ];
 				if( getDateHelper().isDateObject( cellValue ) )
 					cellValue = DateTimeFormat( cellValue, library().getDateFormats().DATETIME );
 				if( IsValid( "integer", cellValue ) )
 					cellValue = JavaCast( "string", cellValue );// prevent CSV writer converting 1 to 1.0
 				rowValues.Append( cellValue );
-			}
+			});
 			result.Append( rowValues );
-		}
+		}, arguments.threads gt 1, arguments.threads)
 		return result;
 	}
 


### PR DESCRIPTION
added threads to csv generation. in my performance testing with 10mb files it was 2-3x faster with just two threads.

_row order is not guaranteed_! speed is more important than order for my use case.