### PR TITLE
Handle invalid formula cell gracefully

### DIFF
--- a/helpers/cell.cfc
+++ b/helpers/cell.cfc
@@ -227,7 +227,12 @@ component extends="base"{
 			return getCellNumericOrDateValue( arguments.cell ); 
 		if( arguments.cell.getCachedFormulaResultType() == arguments.cell.getCellType().BOOLEAN )
 			return arguments.cell.getBooleanCellValue();
-		return arguments.cell.getStringCellValue();
+		try{
+			return arguments.cell.getStringCellValue();
+		}
+		catch( any exception ){
+			return "";
+		}
 	}
 
 }


### PR DESCRIPTION
A customer was uploading a spreadsheet with what I'm assuming is an invalid formula cell.

This fixes the below anyway:
> java.lang.IllegalStateException: Cannot get a STRING value from a ERROR formula cell at org.apache.poi.hssf.usermodel.HSSFCell.typeMismatch(HSSFCell.java:649) at org.apache.poi.hssf.usermodel.HSSFCell.checkFormulaCachedValueType(HSSFCell.java:655) at org.apache.poi.hssf.usermodel.HSSFCell.getRichStringCellValue(HSSFCell.java:756) at org.apache.poi.hssf.usermodel.HSSFCell.getStringCellValue(HSSFCell.java:733) at jdk.internal.reflect.GeneratedMethodAccessor190.invoke(Unknown Source) at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.base/java.lang.reflect.Method.invoke(Method.java:566) at coldfusion.runtime.StructBean.invoke(StructBean.java:507) at coldfusion.runtime.CfJspPage._invoke(CfJspPage.java:3723) at coldfusion.runtime.CfJspPage._invoke(CfJspPage.java:3604) at cfcell2ecfc108041242$funcGETCACHEDFORMULAVALUE.runFunction(/var/www/cfcs/utility/cfspreadsheet/helpers/cell.cfc:242)